### PR TITLE
Update VisibleSignatureImage.java

### DIFF
--- a/commons/pdf-commons/pom.xml
+++ b/commons/pdf-commons/pom.xml
@@ -5,7 +5,7 @@
 
   <artifactId>signservice-pdf-commons</artifactId>
   <packaging>jar</packaging>
-  <version>1.0.3</version>
+  <version>1.0.4-SNAPSHOT</version>
 
   <parent>
     <groupId>se.idsec.signservice.commons</groupId>

--- a/commons/pdf-commons/pom.xml
+++ b/commons/pdf-commons/pom.xml
@@ -10,7 +10,7 @@
   <parent>
     <groupId>se.idsec.signservice.commons</groupId>
     <artifactId>signservice-commons-parent</artifactId>
-    <version>1.0.2</version>
+    <version>1.0.3-SNAPSHOT</version>
   </parent>
 
   <name>IDsec Solutions :: SignService :: Commons :: PDF Commons</name>
@@ -60,7 +60,7 @@
     <dependency>
       <groupId>se.idsec.signservice.commons</groupId>
       <artifactId>signservice-commons</artifactId>
-      <version>1.0.2</version>
+      <version>1.0.3-SNAPSHOT</version>
     </dependency>
 
     <dependency>
@@ -70,7 +70,18 @@
 
     <dependency>
       <groupId>org.bouncycastle</groupId>
+      <artifactId>bcprov-jdk15on</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.bouncycastle</groupId>
       <artifactId>bcpkix-jdk15on</artifactId>
+    </dependency>
+    
+    <dependency>
+      <groupId>commons-io</groupId>
+      <artifactId>commons-io</artifactId>
+      <version>2.4</version>
     </dependency>
 
     <dependency>
@@ -85,6 +96,10 @@
         <exclusion>
           <groupId>xml-apis</groupId>
           <artifactId>xml-apis</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>commons-io</groupId>
+          <artifactId>commons-io</artifactId>
         </exclusion>
       </exclusions>
     </dependency>

--- a/commons/pdf-commons/src/main/java/se/idsec/signservice/security/sign/pdf/document/VisibleSignatureImage.java
+++ b/commons/pdf-commons/src/main/java/se/idsec/signservice/security/sign/pdf/document/VisibleSignatureImage.java
@@ -57,7 +57,10 @@ import lombok.extern.slf4j.Slf4j;
 public class VisibleSignatureImage {
 
   /** Default date format. */
-  public SimpleDateFormat dateFormat = new SimpleDateFormat("yyyy-MM-dd HH:mm z");
+  public static final String DEFAULT_DATE_FORMAT = "yyyy-MM-dd HH:mm z";
+
+  /** Date format for signing time. The default is {@link #DEFAULT_DATE_FORMAT}. */
+  private SimpleDateFormat dateFormat = new SimpleDateFormat(DEFAULT_DATE_FORMAT);
 
   /** Constant representing "first page" (1). */
   public static final int FIRST_PAGE = 1;

--- a/commons/pdf-commons/src/main/java/se/idsec/signservice/security/sign/pdf/document/VisibleSignatureImage.java
+++ b/commons/pdf-commons/src/main/java/se/idsec/signservice/security/sign/pdf/document/VisibleSignatureImage.java
@@ -60,7 +60,7 @@ public class VisibleSignatureImage {
   public static final String DEFAULT_DATE_FORMAT = "yyyy-MM-dd HH:mm z";
 
   /** Date format for signing time. The default is {@link #DEFAULT_DATE_FORMAT}. */
-  private SimpleDateFormat dateFormat = new SimpleDateFormat(DEFAULT_DATE_FORMAT);
+  private SimpleDateFormat dateFormat;
 
   /** Constant representing "first page" (1). */
   public static final int FIRST_PAGE = 1;
@@ -220,6 +220,38 @@ public class VisibleSignatureImage {
     }
   }
 
+  /**
+   * Assigns the date format for signing time. The default is {@link #DEFAULT_DATE_FORMAT}.
+   * 
+   * @param dateFormat
+   *          the date format for signing time
+   */
+  public void setDateFormat(final SimpleDateFormat dateFormat) {
+    this.dateFormat = dateFormat;
+  }
+
+  /**
+   * Assigns the date format for signing time. The default is {@link #DEFAULT_DATE_FORMAT}.
+   * 
+   * @param dateFormat
+   *          the date format for signing time
+   */
+  public void setDateFormat(final String dateFormat) {
+    this.dateFormat = new SimpleDateFormat(dateFormat);
+  }
+
+  /**
+   * Gets the date format for signing time.
+   * 
+   * @return the date format for signing time
+   */
+  public SimpleDateFormat getDateFormat() {
+    if (this.dateFormat == null) {
+      this.setDateFormat(DEFAULT_DATE_FORMAT);
+    }
+    return this.dateFormat;
+  }
+
   private InputStream createImageFromSVG(final String svg) throws TranscoderException {
     final Reader reader = new BufferedReader(new StringReader(svg));
     final TranscoderInput svgImage = new TranscoderInput(reader);
@@ -243,7 +275,7 @@ public class VisibleSignatureImage {
     }
 
     if (this.includeDate) {
-      personalizedJson = personalizedJson.replaceAll("##SIGNTIME##", dateFormat.format(signingTime));
+      personalizedJson = personalizedJson.replaceAll("##SIGNTIME##", this.getDateFormat().format(signingTime));
     }
     return personalizedJson;
   }

--- a/commons/pdf-commons/src/main/java/se/idsec/signservice/security/sign/pdf/document/VisibleSignatureImage.java
+++ b/commons/pdf-commons/src/main/java/se/idsec/signservice/security/sign/pdf/document/VisibleSignatureImage.java
@@ -56,8 +56,8 @@ import lombok.extern.slf4j.Slf4j;
 @Slf4j
 public class VisibleSignatureImage {
 
-  /** Basic date format used. */
-  public static final SimpleDateFormat BASIC_DATE_FORMAT = new SimpleDateFormat("yyyy-MM-dd HH:mm");
+  /** Default date format. */
+  public SimpleDateFormat dateFormat = new SimpleDateFormat("yyyy-MM-dd HH:mm z");
 
   /** Constant representing "first page" (1). */
   public static final int FIRST_PAGE = 1;
@@ -240,7 +240,7 @@ public class VisibleSignatureImage {
     }
 
     if (this.includeDate) {
-      personalizedJson = personalizedJson.replaceAll("##SIGNTIME##", VisibleSignatureImage.BASIC_DATE_FORMAT.format(signingTime));
+      personalizedJson = personalizedJson.replaceAll("##SIGNTIME##", dateFormat.format(signingTime));
     }
     return personalizedJson;
   }


### PR DESCRIPTION
Provide configurable date format in Visible Signature Image.

This default should work without any further changes. If necessary, an amendment could be done to be able to set date format in visible signature requirements