### PR TITLE
Update PDFBox to 3.0.3 and refactor loaders

### DIFF
--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -49,7 +49,7 @@
 
   <properties>
     <jackson.version>2.17.1</jackson.version>
-    <pdfbox.version>2.0.32</pdfbox.version>
+    <pdfbox.version>3.0.3</pdfbox.version>
     <bouncy-castle.version>1.78.1</bouncy-castle.version>
     <slf4j.version>2.0.13</slf4j.version>
   </properties>
@@ -295,6 +295,13 @@
         <groupId>se.swedenconnect.security</groupId>
         <artifactId>algorithm-registry</artifactId>
         <version>1.1.0</version>
+      </dependency>
+
+      <!-- Nimbus -->
+      <dependency>
+        <groupId>com.nimbusds</groupId>
+        <artifactId>nimbus-jose-jwt</artifactId>
+        <version>9.40</version>
       </dependency>
 
       <!-- Test -->

--- a/commons/pdf-commons/src/main/java/se/idsec/signservice/security/sign/pdf/impl/BasicPDFSignatureValidator.java
+++ b/commons/pdf-commons/src/main/java/se/idsec/signservice/security/sign/pdf/impl/BasicPDFSignatureValidator.java
@@ -33,6 +33,7 @@ import java.util.Date;
 import java.util.Iterator;
 import java.util.List;
 
+import org.apache.pdfbox.Loader;
 import org.apache.pdfbox.pdmodel.PDDocument;
 import org.apache.pdfbox.pdmodel.interactive.digitalsignature.PDSignature;
 import org.bouncycastle.asn1.ASN1Encodable;
@@ -96,7 +97,7 @@ public class BasicPDFSignatureValidator implements PDFSignatureValidator {
   @Override
   public List<SignatureValidationResult> validate(final byte[] document) throws SignatureException {
 
-    try (final PDDocument pdfDocument = PDDocument.load(document)) {
+    try (final PDDocument pdfDocument = Loader.loadPDF(document)) {
 
       final List<SignatureValidationResult> results = new ArrayList<>();
       final List<PDSignature> signatureDictionaries = pdfDocument.getSignatureDictionaries();
@@ -386,7 +387,7 @@ public class BasicPDFSignatureValidator implements PDFSignatureValidator {
   /** {@inheritDoc} */
   @Override
   public boolean isSigned(final byte[] document) throws IllegalArgumentException {
-    try (final PDDocument pdfDocument = PDDocument.load(document)) {
+    try (final PDDocument pdfDocument = Loader.loadPDF(document)) {
       return !pdfDocument.getSignatureDictionaries().isEmpty();
     }
     catch (final IOException e) {

--- a/commons/pdf-commons/src/main/java/se/idsec/signservice/security/sign/pdf/impl/DefaultPDFSigner.java
+++ b/commons/pdf-commons/src/main/java/se/idsec/signservice/security/sign/pdf/impl/DefaultPDFSigner.java
@@ -22,6 +22,7 @@ import java.security.cert.X509Certificate;
 import java.util.Arrays;
 import java.util.List;
 
+import org.apache.pdfbox.Loader;
 import org.apache.pdfbox.pdmodel.PDDocument;
 import org.bouncycastle.asn1.x509.AlgorithmIdentifier;
 
@@ -122,7 +123,7 @@ public class DefaultPDFSigner implements PDFSigner {
     if (parameters == null) {
       return this.sign(document);
     }
-    try (final PDDocument pdfDocument = PDDocument.load(document)) {
+    try (final PDDocument pdfDocument = Loader.loadPDF(document)) {
       final List<X509Certificate> signingCertChain = this.includeCertificateChain
           ? this.signingCredential.getCertificateChain()
           : Arrays.asList(this.signingCredential.getCertificate());


### PR DESCRIPTION
Upgraded Apache PDFBox version from 2.0.32 to 3.0.3. Refactored `DefaultPDFSigner` and `BasicPDFSignatureValidator` to use the new `Loader.loadPDF` method. Added Nimbus JOSE JWT dependency in the POM file.

Using PDFBox 3 is fine. Minor updates.

Also added Nimbus dependency as the version imported from AlgorithmReigistry contains vulnerabilities.

I have tested this update with signservice-integration, and further tested this with my signservice self-test SP. No convergence errors and no problems.

I think this one is ready for release