### PR TITLE
Add timezone support

### DIFF
--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -48,9 +48,9 @@
   </developers>
 
   <properties>
-    <jackson.version>2.18.2</jackson.version>
-    <pdfbox.version>3.0.3</pdfbox.version>
-    <bouncy-castle.version>1.79</bouncy-castle.version>
+    <jackson.version>2.18.3</jackson.version>
+    <pdfbox.version>3.0.4</pdfbox.version>
+    <bouncy-castle.version>1.80</bouncy-castle.version>
     <slf4j.version>2.0.16</slf4j.version>
   </properties>
 
@@ -138,19 +138,19 @@
       <dependency>
         <groupId>commons-codec</groupId>
         <artifactId>commons-codec</artifactId>
-        <version>1.17.2</version>
+        <version>1.18.0</version>
       </dependency>
 
       <dependency>
         <groupId>commons-logging</groupId>
         <artifactId>commons-logging</artifactId>
-        <version>1.3.4</version>
+        <version>1.3.5</version>
       </dependency>
 
       <dependency>
         <groupId>commons-beanutils</groupId>
         <artifactId>commons-beanutils</artifactId>
-        <version>1.10.0</version>
+        <version>1.10.1</version>
       </dependency>
 
       <!-- Servlet API -->
@@ -211,7 +211,7 @@
       <dependency>
         <groupId>org.apache.httpcomponents.core5</groupId>
         <artifactId>httpcore5</artifactId>
-        <version>5.3.2</version>
+        <version>5.3.3</version>
       </dependency>
 
       <!-- JAXB -->
@@ -269,19 +269,19 @@
       <dependency>
         <groupId>se.swedenconnect.opensaml</groupId>
         <artifactId>opensaml-security-ext</artifactId>
-        <version>4.1.2</version>
+        <version>4.1.4</version>
       </dependency>
 
       <dependency>
         <groupId>se.swedenconnect.opensaml</groupId>
         <artifactId>opensaml-addons</artifactId>
-        <version>2.1.2</version>
+        <version>2.1.3</version>
       </dependency>
 
       <dependency>
         <groupId>se.swedenconnect.opensaml</groupId>
         <artifactId>opensaml-swedish-eid</artifactId>
-        <version>2.2.2</version>
+        <version>2.2.3</version>
       </dependency>
 
       <!-- Sweden Connect Credentials Support -->
@@ -301,7 +301,7 @@
       <dependency>
         <groupId>com.nimbusds</groupId>
         <artifactId>nimbus-jose-jwt</artifactId>
-        <version>9.48</version>
+        <version>10.0.2</version>
       </dependency>
 
       <!-- Test -->
@@ -310,21 +310,21 @@
       <dependency>
         <groupId>org.junit.jupiter</groupId>
         <artifactId>junit-jupiter</artifactId>
-        <version>5.11.4</version>
+        <version>5.12.0</version>
         <scope>test</scope>
       </dependency>
 
       <dependency>
         <groupId>org.junit.jupiter</groupId>
         <artifactId>junit-jupiter-params</artifactId>
-        <version>5.11.4</version>
+        <version>5.12.0</version>
         <scope>test</scope>
       </dependency>
 
       <dependency>
         <groupId>org.mockito</groupId>
         <artifactId>mockito-core</artifactId>
-        <version>5.15.2</version>
+        <version>5.16.0</version>
         <scope>test</scope>
       </dependency>
 

--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -6,7 +6,7 @@
   <groupId>se.idsec.signservice.commons</groupId>
   <artifactId>signservice-bom</artifactId>
   <packaging>pom</packaging>
-  <version>2.2.0</version>
+  <version>2.2.1-SNAPSHOT</version>
 
   <name>IDsec Solutions :: BOM for SignService</name>
   <description>BOM for SignService</description>

--- a/commons/pdf-commons/pom.xml
+++ b/commons/pdf-commons/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <groupId>se.idsec.signservice.commons</groupId>
     <artifactId>signservice-commons-parent</artifactId>
-    <version>2.2.0</version>
+    <version>2.2.1-SNAPSHOT</version>
   </parent>
 
   <name>IDsec Solutions :: SignService :: Commons :: PDF Commons</name>

--- a/commons/pdf-commons/src/main/java/se/idsec/signservice/security/sign/pdf/document/VisibleSignatureImage.java
+++ b/commons/pdf-commons/src/main/java/se/idsec/signservice/security/sign/pdf/document/VisibleSignatureImage.java
@@ -41,6 +41,7 @@ import java.text.SimpleDateFormat;
 import java.util.Date;
 import java.util.Map;
 import java.util.Set;
+import java.util.TimeZone;
 
 /**
  * Data object holding the parameters necessary to provide a signature image to a PDF document.
@@ -57,6 +58,8 @@ public class VisibleSignatureImage {
 
   /** Default date format. */
   public static final String DEFAULT_DATE_FORMAT = "yyyy-MM-dd HH:mm z";
+
+  public static final TimeZone DEFAULT_TIMEZONE = TimeZone.getDefault();
 
   /** Constant representing "first page" (1). */
   public static final int FIRST_PAGE = 1;
@@ -93,6 +96,9 @@ public class VisibleSignatureImage {
 
   /** The contents of the SVG image. */
   private String svgImage;
+
+  /** The time zone for signing time. The default is {@link #DEFAULT_TIMEZONE} */
+  private String timeZoneId;
 
   /**
    * Generates PDFBox signature options that includes the visible signature.
@@ -181,7 +187,14 @@ public class VisibleSignatureImage {
   }
 
   private SimpleDateFormat createDateFormatter() {
-    return this.dateFormat != null ? new SimpleDateFormat(this.dateFormat) : new SimpleDateFormat(DEFAULT_DATE_FORMAT);
+    SimpleDateFormat createdDateFormat = this.dateFormat != null
+        ? new SimpleDateFormat(this.dateFormat)
+        : new SimpleDateFormat(DEFAULT_DATE_FORMAT);
+    TimeZone usedTimeZone = this.timeZoneId != null
+        ? TimeZone.getTimeZone(this.timeZoneId)
+        : DEFAULT_TIMEZONE;
+    createdDateFormat.setTimeZone(usedTimeZone);
+    return createdDateFormat;
   }
 
 }

--- a/commons/pdf-commons/src/test/java/se/idsec/signservice/security/sign/pdf/document/VisibleSignatureImageTest.java
+++ b/commons/pdf-commons/src/test/java/se/idsec/signservice/security/sign/pdf/document/VisibleSignatureImageTest.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright 2019-2025 IDsec Solutions AB
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package se.idsec.signservice.security.sign.pdf.document;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.text.SimpleDateFormat;
+import java.util.Date;
+import java.util.TimeZone;
+
+class VisibleSignatureImageTest {
+
+  @Test
+  void testCreateDateFormatterWithNullValues() {
+    final VisibleSignatureImage visibleSignatureImage = new VisibleSignatureImage();
+    final SimpleDateFormat formatter = visibleSignatureImage.createDateFormatter();
+    Assertions.assertEquals(VisibleSignatureImage.DEFAULT_DATE_FORMAT, formatter.toPattern());
+    Assertions.assertEquals(VisibleSignatureImage.DEFAULT_TIMEZONE, formatter.getTimeZone());
+  }
+
+  @Test
+  void testCreateDateFormatterWithCustomValues() {
+    final VisibleSignatureImage visibleSignatureImage = new VisibleSignatureImage();
+    visibleSignatureImage.setDateFormat("yyyy-MM-dd HH:mm z");
+    visibleSignatureImage.setTimeZoneId("UTC");
+    final SimpleDateFormat formatter = visibleSignatureImage.createDateFormatter();
+    Assertions.assertEquals("yyyy-MM-dd HH:mm z", formatter.toPattern());
+    Assertions.assertEquals(TimeZone.getTimeZone("UTC"), formatter.getTimeZone());
+  }
+
+  @Test
+  void testCreateDateFormatterSweden() {
+    final VisibleSignatureImage visibleSignatureImage = new VisibleSignatureImage();
+    visibleSignatureImage.setDateFormat("yyyy-MM-dd HH:mm:ss z");
+    visibleSignatureImage.setTimeZoneId("Europe/Stockholm");
+    final SimpleDateFormat formatter = visibleSignatureImage.createDateFormatter();
+
+    Assertions.assertEquals("1970-01-01 01:00:00 CET", formatter.format(new Date(0)));
+  }
+
+  @Test
+  void setTimeZoneId_Should_ThrowException_When_ZoneIdIsInvalid() {
+    final VisibleSignatureImage visibleSignatureImage = new VisibleSignatureImage();
+    Assertions.assertThrows(IllegalArgumentException.class,
+        () -> visibleSignatureImage.setTimeZoneId("invalid/zoneid"));
+    Assertions.assertThrows(IllegalArgumentException.class,
+        () -> VisibleSignatureImage.builder().timeZoneId("invalid/zoneid").build());
+  }
+
+  @Test
+  void setTimeZoneId_Should_NotThrowException_When_ZoneIdIsValid() {
+    final VisibleSignatureImage visibleSignatureImage = new VisibleSignatureImage();
+    Assertions.assertDoesNotThrow(() -> visibleSignatureImage.setTimeZoneId("Europe/Stockholm"));
+    Assertions.assertDoesNotThrow(() -> VisibleSignatureImage.builder().timeZoneId("Europe/Stockholm").build());
+  }
+
+  @Test
+  void setDateFormat_Should_ThrowException_When_FormatIsInvalid() {
+    final VisibleSignatureImage visibleSignatureImage = new VisibleSignatureImage();
+    Assertions.assertThrows(IllegalArgumentException.class,
+        () -> visibleSignatureImage.setDateFormat("invalid/format"));
+
+    Assertions.assertThrows(IllegalArgumentException.class,
+        () -> VisibleSignatureImage.builder().dateFormat("invalid/format").build());
+  }
+
+  @Test
+  void setDateFormat_Should_NotThrowException_When_FormatIsValid() {
+    final VisibleSignatureImage visibleSignatureImage = new VisibleSignatureImage();
+    Assertions.assertDoesNotThrow(() -> visibleSignatureImage.setDateFormat("yyyy-MM-dd HH:mm z"));
+    Assertions.assertDoesNotThrow(() -> VisibleSignatureImage.builder().dateFormat("yyyy-MM-dd HH:mm z").build());
+  }
+}

--- a/commons/pom.xml
+++ b/commons/pom.xml
@@ -51,7 +51,7 @@
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <java.version>17</java.version>
-    <spring.version>6.2.1</spring.version>
+    <spring.version>6.2.4</spring.version>
   </properties>
 
   <repositories>
@@ -91,7 +91,7 @@
       <dependency>
         <groupId>se.idsec.signservice.commons</groupId>
         <artifactId>signservice-bom</artifactId>
-        <version>2.2.0</version>
+        <version>2.2.1-SNAPSHOT</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>
@@ -143,7 +143,7 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-surefire-plugin</artifactId>
-          <version>3.4.0</version>
+          <version>3.5.2</version>
         </plugin>
 
         <plugin>
@@ -161,7 +161,7 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-javadoc-plugin</artifactId>
-          <version>3.8.0</version>
+          <version>3.10.1</version>
         </plugin>
 
         <plugin>

--- a/commons/pom.xml
+++ b/commons/pom.xml
@@ -7,7 +7,7 @@
   <groupId>se.idsec.signservice.commons</groupId>
   <artifactId>signservice-commons-parent</artifactId>
   <packaging>pom</packaging>
-  <version>2.2.0</version>
+  <version>2.2.1-SNAPSHOT</version>
 
   <name>IDsec Solutions :: Parent POM for SignService :: Commons</name>
   <description>Parent POM for SignService Commons libraries</description>

--- a/commons/signservice-commons/pom.xml
+++ b/commons/signservice-commons/pom.xml
@@ -9,7 +9,7 @@
   <parent>
     <groupId>se.idsec.signservice.commons</groupId>
     <artifactId>signservice-commons-parent</artifactId>
-    <version>2.2.0</version>
+    <version>2.2.1-SNAPSHOT</version>
   </parent>
 
   <name>IDsec Solutions :: SignService :: Commons :: Utilities</name>

--- a/commons/xml-commons/pom.xml
+++ b/commons/xml-commons/pom.xml
@@ -9,7 +9,7 @@
   <parent>
     <groupId>se.idsec.signservice.commons</groupId>
     <artifactId>signservice-commons-parent</artifactId>
-    <version>2.2.0</version>
+    <version>2.2.1-SNAPSHOT</version>
   </parent>
 
   <name>IDsec Solutions :: SignService :: Commons :: XML Commons</name>


### PR DESCRIPTION
Updated pom files to reflect the new version 2.2.1-SNAPSHOT for ongoing development. Introduced timezone support in `VisibleSignatureImage`, allowing customization of time zone in signature formatting with a default fallback. This ensures more precise control over date and time handling in PDF signing.